### PR TITLE
Fix className for Camera

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.17.2
+    Fix Camera component to use props.className
+
 ## 3.17.1
     Updated GroupCircled to contain lock
     Updated GroupCircled to take a maskId identifier to avoid id conflicts

--- a/app/components/Camera.js
+++ b/app/components/Camera.js
@@ -5,14 +5,9 @@ const Camera = React.createClass({
   displayName: 'Camera',
 
   render() {
-    const classes = classnames({
-      'tilt-icon': true,
-      'tilt-camera': true,
-      [this.props.className]: !!this.props.className
-    });
-
     return (
-      <svg width="26px" height="23px" viewBox="0 0 26 23" version="1.1">
+      <svg width="26px" height="23px" viewBox="0 0 26 23" version="1.1"
+            className={classnames('tilt-icon tilt-camera', this.props.className)}>
         <title>camera</title>
         <defs></defs>
         <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">


### PR DESCRIPTION
I needed to add a class to the camera icon SVG, and it was previously ignoring className prop being sent in as well as not applying tilt-icon and tilt-camera classes.