### PR TITLE
changes "main" entry of package.json to be app/index.js

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.0
+    Changes "main" entry point to eliminate need for webpack aliases
+
 ## 6.9.1
     Added Bank Icon
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "tilt-images",
   "repository": "git@github.com:Crowdtilt/tilt-images.git",
-  "version": "6.9.1",
+  "version": "7.0.0",
   "description": "SVG images used on the tilt websites",
-  "main": "server.js",
+  "main": "app/index.js",
   "scripts": {
     "start": "babel-node server.js",
     "test": "npm run unit-test",


### PR DESCRIPTION
This is a breaking change (hence major version bump), but allows us to eliminate one of the headaches of porting web-dancer code to web: different webpack aliases. To update our repos:
web: replace all instances of `require('tilt-images/app/foo')` with `require('tilt-images/foo')`
web-dancer: remove the tilt-images webpack alias(es) from our various webpack configs

We can't just create the webpack alias in web, since we run server tests via mocha, which doesn't currently play nicely with webpack.