### PR TITLE
Bump version to match tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tilt-images",
   "repository": "git@github.com:Crowdtilt/tilt-images.git",
-  "version": "6.9.1",
+  "version": "6.9.2",
   "description": "SVG images used on the tilt websites",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
makes npm install output pretty confusing otherwise